### PR TITLE
ファイル名が重複していたらDBもファイルも登録しないようにした。

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -51,20 +51,23 @@ def uploadMusic():
     fileType = request.form["type"]
     fileName = f.filename
     filePath = 'static/musics/'+fileName
-    f.save(filePath)
-    fileSize = convert_size(os.path.getsize(filePath))
-    newMusic = Music(
-        musicName=fileName,
-        time=time,
-        fileType=fileType,
-        fileSize=fileSize,
-        fileName=fileName,
-    )
-    db.session.add(newMusic)
-    db.session.commit()
-    print(f)
-    print(os.getcwd())
-    return jsonify({"filename": f.filename})
+    if os.path.exists(filePath):
+        return jsonify({"message": "Uploaded file already exists"}), 500
+    else:
+        f.save(filePath)
+        fileSize = convert_size(os.path.getsize(filePath))
+        newMusic = Music(
+            musicName=fileName,
+            time=time,
+            fileType=fileType,
+            fileSize=fileSize,
+            fileName=fileName,
+        )
+        db.session.add(newMusic)
+        db.session.commit()
+        print(f)
+        print(os.getcwd())
+        return jsonify({"filename": f.filename})
 
 
 def convert_size(size):

--- a/front/src/UploadPage.tsx
+++ b/front/src/UploadPage.tsx
@@ -27,6 +27,11 @@ const UploadPage = () => {
         console.log(status, meta, file)
         if (status === 'done') {
             console.log(JSON.parse(xhr.response));
+            return;
+        }
+        if (status === 'error_upload') {
+            // TODO:エラー時のレスポンスがnullになってしまうので、後で要修正。
+            console.log(xhr);
         }
     }
 


### PR DESCRIPTION
API側でエラーハンドリングをしているが、Dropzoneのエラー時のresponseがnullになってしまうので、他に何か手を考える。