### PR TITLE
カラムにUNIQUEを付与した際のエラーを解消

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -3,13 +3,23 @@ from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
 from flask_marshmallow import Marshmallow
 from flask_cors import CORS
+from sqlalchemy import MetaData
 
 app = Flask(__name__)
+CORS(app, supports_credentials=True)
 
-CORS(app,supports_credentials=True)
+convention = {
+    "ix": 'ix_%(column_0_label)s',
+    "uq": "uq_%(table_name)s_%(column_0_name)s",
+    "ck": "ck_%(table_name)s_%(constraint_name)s",
+    "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
+    "pk": "pk_%(table_name)s"
+}
+
 # config
 app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///database/database.db'
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-db = SQLAlchemy(app)
+metadata = MetaData(naming_convention=convention)
+db = SQLAlchemy(app, metadata=metadata)
 migrate = Migrate(app, db, render_as_batch=True)
 ma = Marshmallow(app)


### PR DESCRIPTION
参考記事：https://stackoverflow.com/questions/62640576/flask-migrate-valueerror-constraint-must-have-a-name