### PR TITLE
編集モーダルのコンポーネント化。album新規登録に編集モーダルコンポーネント適用。

### DIFF
--- a/front/src/AlbumPage.tsx
+++ b/front/src/AlbumPage.tsx
@@ -1,20 +1,17 @@
 import * as React from 'react';
-import { useTheme } from '@mui/material/styles';
 import { useState } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import axios from 'axios';
 // component
 import Header from './component/Header';
+import EditModal from './component/EditModal';
 import {
-    Box, Typography, Grid, Button, Modal, TextField, Backdrop, Snackbar, Alert, CircularProgress
+    Typography, Grid, Button, TextField,
 } from '@mui/material'
 // types
 import { Album } from './types/albums';
-// redux
-import { useDispatch } from 'react-redux';
 
 export default function AlbumPage() {
-    const theme = useTheme();
     return (
         <div>
             <Header></Header>
@@ -40,27 +37,13 @@ export default function AlbumPage() {
     );
 }
 
-export const CreateModal = () => {
-    const dispatch = useDispatch();
+export const CreateModal: React.FC = () => {
     const [isOpenModal, setIsOpenModal] = useState(false);
     const [isProgress, setIsProgress] = useState(false);
     const [isSnackOpen, setIsSnackOpen] = useState(false);
-    const [albums, setAlbums] = useState<Album[]>([]);
     const modalOpen = () => setIsOpenModal(true);
     const modalClose = () => setIsOpenModal(false);
     const { register, handleSubmit } = useForm<Album>();
-
-    const style = {
-        position: 'absolute' as 'absolute',
-        top: '50%',
-        left: '50%',
-        transform: 'translate(-50%, -50%)',
-        width: '80vw',
-        bgcolor: 'background.paper',
-        border: '2px solid #000',
-        boxShadow: 24,
-        p: 4,
-    };
 
     const onSubmit: SubmitHandler<Album> = async (data) => {
         setIsProgress(true);
@@ -73,57 +56,42 @@ export const CreateModal = () => {
         setIsSnackOpen(true);
     }
 
-    const snackbarClose = (event: React.SyntheticEvent | Event, reason?: string) => {
-        if (reason === 'clickaway') {
-            return;
-        }
-        setIsSnackOpen(false);
-    };
+    const openButton = <Button variant="contained" size='large' style={{ textTransform: "none" }} onClick={modalOpen}>CreateAlbum</Button>;
+    const editTitle = <Typography id="modal-modal-title" variant="h6" component="h2">CreateAlbum</Typography>
+    const editContent = (
+        <Typography id="modal-modal-description" sx={{
+            mt: 2, '& .MuiTextField-root': { m: 1 },
+        }}>
+            <div>
+                <TextField style={{ width: '25ch' }} label="albumName" type="text" {...register('albumName')} variant="standard" />
+            </div>
+            <div>
+                <Button
+                    sx={{ mt: 2 }}
+                    color="primary"
+                    variant="contained"
+                    size="large"
+                    onClick={handleSubmit(onSubmit)}
+                >
+                    submit
+                </Button>
+            </div>
+        </Typography>
+    )
 
     return (
         <div>
-            <Button variant="contained" size='large' style={{ textTransform: "none" }} onClick={modalOpen}>CreateAlbum</Button>
-            <Modal
-                open={isOpenModal}
-                onClose={modalClose}
-                aria-labelledby="modal-modal-title"
-                aria-describedby="modal-modal-description"
-            >
-                <Box sx={style}>
-                    <Typography id="modal-modal-title" variant="h6" component="h2">
-                        CreateAlbum
-                    </Typography>
-                    <Typography id="modal-modal-description" sx={{
-                        mt: 2, '& .MuiTextField-root': { m: 1 },
-                    }}>
-                        <div>
-                            <TextField style={{ width: '25ch' }} label="albumName" type="text" {...register('albumName')} variant="standard" />
-                        </div>
-                        <div>
-                            <Button
-                                sx={{ mt: 2 }}
-                                color="primary"
-                                variant="contained"
-                                size="large"
-                                onClick={handleSubmit(onSubmit)}
-                            >
-                                submit
-                            </Button>
-                        </div>
-                    </Typography>
-                </Box>
-            </Modal>
-            <Backdrop
-                sx={{ color: '#fff', zIndex: 1301 }}
-                open={isProgress}
-            >
-                <CircularProgress color="inherit" />
-            </Backdrop>
-            <Snackbar open={isSnackOpen} autoHideDuration={2000} onClose={snackbarClose} anchorOrigin={{ vertical: 'top', horizontal: 'center' }}>
-                <Alert onClose={snackbarClose} severity="success" variant="filled" sx={{ width: '100%' }}>
-                    Save successfully!
-                </Alert>
-            </Snackbar>
+            <EditModal
+                setIsSnackOpen={setIsSnackOpen}
+                modalOpen={modalOpen}
+                modalClose={modalClose}
+                isOpenModal={isOpenModal}
+                isProgress={isProgress}
+                isSnackOpen={isSnackOpen}
+                openButton={openButton}
+                editTitle={editTitle}
+                editContent={editContent}
+            />
         </div>
     );
 }

--- a/front/src/component/EditModal.tsx
+++ b/front/src/component/EditModal.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import {
+    Box, Modal, Backdrop, Snackbar, Alert, CircularProgress
+} from '@mui/material'
+
+type Props = {
+    setIsSnackOpen: React.Dispatch<React.SetStateAction<boolean>>,
+    modalOpen: () => void,
+    modalClose: () => void,
+    isOpenModal: boolean,
+    isProgress: boolean,
+    isSnackOpen: boolean,
+    openButton: JSX.Element,
+    editTitle: JSX.Element,
+    editContent: JSX.Element,
+}
+
+const EditModal: React.FC<Props> = (props: Props) => {
+    const {
+        setIsSnackOpen, modalClose,
+        isOpenModal,
+        isProgress,
+        isSnackOpen,
+        openButton,
+        editTitle,
+        editContent,
+    } = props;
+    const style = {
+        position: 'absolute' as 'absolute',
+        top: '50%',
+        left: '50%',
+        transform: 'translate(-50%, -50%)',
+        width: '80vw',
+        bgcolor: 'background.paper',
+        border: '2px solid #000',
+        boxShadow: 24,
+        p: 4,
+    };
+
+    const snackbarClose = (event: React.SyntheticEvent | Event, reason?: string) => {
+        if (reason === 'clickaway') {
+            return;
+        }
+        setIsSnackOpen(false);
+    };
+
+    return (
+        <div>
+            {openButton}
+            <Modal
+                open={isOpenModal}
+                onClose={modalClose}
+                aria-labelledby="modal-modal-title"
+                aria-describedby="modal-modal-description"
+            >
+                <Box sx={style}>
+                    {editTitle}
+                    {editContent}
+                </Box>
+            </Modal>
+            <Backdrop
+                sx={{ color: '#fff', zIndex: 1301 }}
+                open={isProgress}
+            >
+                <CircularProgress color="inherit" />
+            </Backdrop>
+            <Snackbar open={isSnackOpen} autoHideDuration={2000} onClose={snackbarClose} anchorOrigin={{ vertical: 'top', horizontal: 'center' }}>
+                <Alert onClose={snackbarClose} severity="success" variant="filled" sx={{ width: '100%' }}>
+                    Save successfully!
+                </Alert>
+            </Snackbar>
+        </div>
+    )
+}
+
+export default EditModal;


### PR DESCRIPTION
- 編集モーダルをコンポーネントに切り出した（propsでモーダルオープンボタン・入力フォーム・Submitボタンを独自に渡す）
- album新規登録に編集モーダルコンポーネント適用