### PR TITLE
アルバム一覧にて、アルバム名が改行されてしまうのを防止

### DIFF
--- a/front/src/AlbumPage.tsx
+++ b/front/src/AlbumPage.tsx
@@ -56,6 +56,7 @@ export default function AlbumPage() {
                 </Grid>
                 <Grid item xs={1}></Grid>
             </Grid>
+            <div style={{ height: '150px' }}></div>
         </div >
     );
 }
@@ -133,7 +134,7 @@ export const AlbumMedia = (props: { album: AlbumAddMusicCount }) => {
                     alt="album-photo"
                 />
                 <CardContent>
-                    <Typography gutterBottom variant="h5" component="div" height={25}>
+                    <Typography noWrap variant="h5" component="div" height={25}>
                         {props.album.albumName ? props.album.albumName : 'Unknown'}
                     </Typography>
                     <Typography variant="body2" color="text.secondary">


### PR DESCRIPTION
- アルバム一覧でアルバム名が長くて日本語のものはcardMedia内で改行されてしまい、見た目が悪いので改行させないようにした。（末尾に...が付与される）
- フッターが表示された状態でもページ内が見やすくなるように空白を追加