### PR TITLE
アルバム＿音源一覧表示対応。アルバムページが切り替わった際の連続再生対応。

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -30,6 +30,12 @@ def getMusics():
     return jsonify(MusicSchema(many=True).dump(musics))
 
 
+@app.route("/musics/<albumName>", methods=['GET'])
+def getAlbum_Music(albumName):
+    musics = Music.query.filter(Music.album == albumName).all()
+    return jsonify(MusicSchema(many=True).dump(musics))
+
+
 @app.route("/music/<id>", methods=['GET'])
 def getMusic(id):
     music = Music.query.filter(Music.id == id).one()

--- a/front/src/AlbumPage.tsx
+++ b/front/src/AlbumPage.tsx
@@ -2,16 +2,28 @@ import React, { useEffect } from 'react';
 import { useState } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import axios from 'axios';
+import { Howl } from 'howler';
 // component
 import Header from './component/Header';
 import EditModal from './component/EditModal';
 import Footer from './component/Footer';
+import MusicTable from './component/MusicsTable';
 import {
     Typography, Grid, Button, TextField, Card, CardActionArea, CardMedia, CardContent,
 } from '@mui/material'
 // types
 import { Album } from './types/albums';
 import { AlbumAddMusicCount } from './types/albumsAddMusicCount';
+import type { Music } from './types/musics';
+import type { MusicResource } from './types/musicResource';
+// Redux
+import { useSelector, useDispatch } from 'react-redux';
+import { store } from './redux/store';
+import { setPlayingId } from './redux/playingIdSlice';
+import { setVolume } from './redux/volumeSlice';
+import { setMusics } from './redux/musicsSlice';
+import { setSounds } from './redux/soundsSlice';
+import { setCurrentSound } from './redux/currentSoundSlice';
 
 export default function AlbumPage() {
     const [albums, setAlbums] = useState<AlbumAddMusicCount[]>([]);
@@ -65,7 +77,7 @@ export default function AlbumPage() {
         );
     }
     return (
-        <div></div>
+        <Album_MusicPage album={selectAlbum}></Album_MusicPage>
     )
 }
 
@@ -151,5 +163,149 @@ export const AlbumMedia = (props: { album: AlbumAddMusicCount, setSelectAlbum: R
                 </CardContent>
             </CardActionArea>
         </Card>
+    )
+}
+
+export const Album_MusicPage = (props: { album: AlbumAddMusicCount }) => {
+    const { album } = props;
+    const [checkedNumbers, setCheckedNumbers] = useState<number[]>([]);
+    const currentSound: MusicResource = useSelector((state: any) => state.currentSounder.currentSound);
+    const musics: Music[] = useSelector((state: any) => state.musics.musics);
+    const sounds: MusicResource[] = useSelector((state: any) => state.sounder.sounds);
+    const playingId: number = useSelector((state: any) => state.playingId.playingId);
+    const dispatch = useDispatch();
+    useEffect(() => {
+        musicsGet();
+        settingGet();
+    }, []);
+    useEffect(() => {
+        createHowler();
+    }, [musics]);
+    useEffect(() => {
+        console.log('選択中のid:' + checkedNumbers.toString());
+    }, [checkedNumbers]);
+    const isDeleteButton = () => {
+        if (checkedNumbers.length !== 0) return true;
+        else return false;
+    }
+    function createHowler() {
+        let newSounds: MusicResource[] = [];
+        musics.forEach(music => {
+            const filepath = 'static/musics/' + music.fileName;
+            if (!sounds.find(el => el.filePath === filepath)) {
+                newSounds.push({
+                    id: music.id,
+                    musicName: music.musicName,
+                    group: music.group,
+                    filePath: filepath,
+                    music_photo: music.music_photo,
+                    howl: new Howl({
+                        src: filepath,
+                        onend: () => {
+                            afterPlayback();
+                        }
+                    })
+                });
+                return;
+            }
+            else {
+                const index = sounds.findIndex((el) => el.filePath === filepath);
+                newSounds.push({
+                    id: music.id,
+                    musicName: music.musicName,
+                    group: music.group,
+                    filePath: filepath,
+                    music_photo: music.music_photo,
+                    howl: sounds[index].howl,
+                })
+            }
+        });
+        // if (!sounds.find(el => el.filePath === currentSound.filePath)) {
+        //     newSounds.push({
+        //         id: currentSound.id,
+        //         musicName: currentSound.musicName,
+        //         group: currentSound.group,
+        //         filePath: currentSound.filePath,
+        //         music_photo: currentSound.music_photo,
+        //         howl: currentSound.howl,
+        //     });
+        // }
+        dispatch(setSounds(newSounds));
+    }
+    function PlaySound(music: Music) {
+        let resource = sounds.find(el => el.filePath === 'static/musics/' + music.fileName);
+        if (!!currentSound.howl && currentSound.howl.playing() === true && currentSound.filePath === resource?.filePath) {
+            currentSound.howl.pause();
+        }
+        else if (!!currentSound.howl && currentSound.filePath !== resource?.filePath) {
+            currentSound.howl.stop();
+            dispatch(setPlayingId(Number(resource?.howl?.play())));
+            if (!!resource)
+                dispatch(setCurrentSound(resource));
+        }
+        else {
+            if (currentSound.howl === undefined && !!resource) {
+                dispatch(setCurrentSound(resource));
+                dispatch(setPlayingId(Number(resource?.howl?.play())));
+            }
+            if (!!currentSound.howl) {
+                currentSound.howl.play();
+            }
+        }
+    }
+    const afterPlayback = () => {
+        const storeState = store.getState();
+        const storeSounds: MusicResource[] = storeState.sounder.sounds;
+        let resource = storeSounds.find(el => el.filePath === storeState.currentSounder.currentSound.filePath);
+        // ループ機能
+        if (storeState.isLooper.isLoop) {
+            dispatch(setCurrentSound(resource));
+            dispatch(setPlayingId(Number(resource?.howl?.play(playingId))));
+            return;
+        }
+        // TODO:自動連続再生 Index番号によって管理 ソートに対応できない場合修正をする事。
+        const currentSoundIndex = storeSounds.findIndex(el => el.filePath === storeState.currentSounder.currentSound.filePath);
+        const nextSound = storeSounds[currentSoundIndex + 1];
+        if (!!nextSound) {
+            dispatch(setCurrentSound(nextSound));
+            dispatch(setPlayingId(Number(nextSound?.howl?.play())));
+        }
+    }
+    function musicsGet() {
+        axios.get("/musics/" + album.albumName)
+            .then((response) => {
+                console.log(response.data);
+                dispatch(setMusics(response.data));
+            });
+    }
+    function musicsDelete(ids: number[]) {
+        console.log(ids);
+        axios.delete("/musics/" + ids)
+            .then((response) => {
+                console.log(response.data);
+                dispatch(setMusics(response.data));
+            })
+        setCheckedNumbers([]);
+    }
+    function settingGet() {
+        axios.get("/settings")
+            .then((response) => {
+                console.log(response.data);
+                dispatch(setVolume(Number(response.data.volume)));
+            });
+        return;
+    }
+
+    return (
+        <div>
+            <MusicTable
+                musics={musics}
+                checkedNumbers={checkedNumbers}
+                setCheckedNumbers={setCheckedNumbers}
+                PlaySound={PlaySound}
+                isDeleteButton={isDeleteButton}
+                musicsDelete={musicsDelete} />
+            <Footer></Footer>
+        </div>
     )
 }

--- a/front/src/AlbumPage.tsx
+++ b/front/src/AlbumPage.tsx
@@ -15,6 +15,7 @@ import { AlbumAddMusicCount } from './types/albumsAddMusicCount';
 
 export default function AlbumPage() {
     const [albums, setAlbums] = useState<AlbumAddMusicCount[]>([]);
+    const [selectAlbum, setSelectAlbum] = useState<AlbumAddMusicCount>();
     useEffect(() => {
         albumsGet();
     }, [])
@@ -25,42 +26,47 @@ export default function AlbumPage() {
                 setAlbums(response.data);
             });
     }
-    return (
-        <div>
-            <Header></Header>
-            <Grid container>
-                <Grid item xs={1}></Grid>
-                <Grid item xs><h1 style={{ color: "white" }}>Album</h1></Grid>
-                <Grid item xs={1}></Grid>
-            </Grid>
-            <Grid container justifyContent="flex-end">
-                <Grid item xs={1}></Grid>
-                <Grid>
-                    <ModalContent />
+    if (!selectAlbum) {
+        return (
+            <div>
+                <Header></Header>
+                <Grid container>
+                    <Grid item xs={1}></Grid>
+                    <Grid item xs><h1 style={{ color: "white" }}>Album</h1></Grid>
+                    <Grid item xs={1}></Grid>
                 </Grid>
-                <Grid item xs={1}></Grid>
-            </Grid>
-
-            <Grid container>
-                <Grid item xs={1}></Grid>
-                <Grid item xs>
-                    <div>
-                        <h2 style={{ color: "white" }}>AlbumList</h2>
-                    </div>
-                    <Grid container spacing={{ xs: 2, md: 3 }} columns={{ xs: 2, sm: 3, md: 4 }}>
-                        {albums.map((album: AlbumAddMusicCount, index) => (
-                            <Grid item xs={1} sm={1} md={1} key={index}>
-                                <AlbumMedia album={(album)} />
-                            </Grid>
-                        ))}
+                <Grid container justifyContent="flex-end">
+                    <Grid item xs={1}></Grid>
+                    <Grid>
+                        <ModalContent />
                     </Grid>
+                    <Grid item xs={1}></Grid>
                 </Grid>
-                <Grid item xs={1}></Grid>
-            </Grid>
-            <div style={{ height: '150px' }}></div>
-            <Footer></Footer>
-        </div >
-    );
+
+                <Grid container>
+                    <Grid item xs={1}></Grid>
+                    <Grid item xs>
+                        <div>
+                            <h2 style={{ color: "white" }}>AlbumList</h2>
+                        </div>
+                        <Grid container spacing={{ xs: 2, md: 3 }} columns={{ xs: 2, sm: 3, md: 4 }}>
+                            {albums.map((album: AlbumAddMusicCount, index) => (
+                                <Grid item xs={1} sm={1} md={1} key={index}>
+                                    <AlbumMedia album={(album)} setSelectAlbum={setSelectAlbum} />
+                                </Grid>
+                            ))}
+                        </Grid>
+                    </Grid>
+                    <Grid item xs={1}></Grid>
+                </Grid>
+                <div style={{ height: '150px' }}></div>
+                <Footer></Footer>
+            </div >
+        );
+    }
+    return (
+        <div></div>
+    )
 }
 
 export const ModalContent: React.FC = () => {
@@ -124,11 +130,11 @@ export const ModalContent: React.FC = () => {
     );
 }
 
-export const AlbumMedia = (props: { album: AlbumAddMusicCount }) => {
-    const { album } = props;
+export const AlbumMedia = (props: { album: AlbumAddMusicCount, setSelectAlbum: React.Dispatch<React.SetStateAction<AlbumAddMusicCount | undefined>> }) => {
+    const { album, setSelectAlbum } = props;
     return (
         <Card sx={{ maxWidth: 345 }}>
-            <CardActionArea>
+            <CardActionArea onClick={() => setSelectAlbum(props.album)}>
                 <CardMedia
                     component="img"
                     height="140"
@@ -145,5 +151,5 @@ export const AlbumMedia = (props: { album: AlbumAddMusicCount }) => {
                 </CardContent>
             </CardActionArea>
         </Card>
-    );
+    )
 }


### PR DESCRIPTION
- アルバム一覧からアルバムを選択するとアルバムに紐づく音源一覧コンポーネントを表示するようにした。
- アルバム＿音源一覧ページに切り替わった際に、連続再生できるようにしてみた。