### PR TITLE
トップページで音源再生→アルバム＿音源一覧ページでループ機能を使用するとundefindエラーが出るので修正

### DIFF
--- a/front/src/AlbumPage.tsx
+++ b/front/src/AlbumPage.tsx
@@ -220,35 +220,25 @@ export const Album_MusicPage = (props: { album: AlbumAddMusicCount }) => {
                 })
             }
         });
-        // if (!sounds.find(el => el.filePath === currentSound.filePath)) {
-        //     newSounds.push({
-        //         id: currentSound.id,
-        //         musicName: currentSound.musicName,
-        //         group: currentSound.group,
-        //         filePath: currentSound.filePath,
-        //         music_photo: currentSound.music_photo,
-        //         howl: currentSound.howl,
-        //     });
-        // }
         dispatch(setSounds(newSounds));
     }
     function PlaySound(music: Music) {
         let resource = sounds.find(el => el.filePath === 'static/musics/' + music.fileName);
-        if (!!currentSound.howl && currentSound.howl.playing() === true && currentSound.filePath === resource?.filePath) {
+        if (!!currentSound?.howl && currentSound?.howl?.playing() === true && currentSound?.filePath === resource?.filePath) {
             currentSound.howl.pause();
         }
-        else if (!!currentSound.howl && currentSound.filePath !== resource?.filePath) {
+        else if (!!currentSound?.howl && currentSound?.filePath !== resource?.filePath) {
             currentSound.howl.stop();
             dispatch(setPlayingId(Number(resource?.howl?.play())));
             if (!!resource)
                 dispatch(setCurrentSound(resource));
         }
         else {
-            if (currentSound.howl === undefined && !!resource) {
+            if (currentSound?.howl === undefined && !!resource) {
                 dispatch(setCurrentSound(resource));
                 dispatch(setPlayingId(Number(resource?.howl?.play())));
             }
-            if (!!currentSound.howl) {
+            if (!!currentSound?.howl) {
                 currentSound.howl.play();
             }
         }

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -78,21 +78,21 @@ function App() {
   }
   function PlaySound(music: Music) {
     let resource = sounds.find(el => el.filePath === 'static/musics/' + music.fileName);
-    if (!!currentSound.howl && currentSound.howl.playing() === true && currentSound.filePath === resource?.filePath) {
+    if (!!currentSound?.howl && currentSound?.howl?.playing() === true && currentSound?.filePath === resource?.filePath) {
       currentSound.howl.pause();
     }
-    else if (!!currentSound.howl && currentSound.filePath !== resource?.filePath) {
+    else if (!!currentSound?.howl && currentSound?.filePath !== resource?.filePath) {
       currentSound.howl.stop();
       dispatch(setPlayingId(Number(resource?.howl?.play())));
       if (!!resource)
         dispatch(setCurrentSound(resource));
     }
     else {
-      if (currentSound.howl === undefined && !!resource) {
+      if (currentSound?.howl === undefined && !!resource) {
         dispatch(setCurrentSound(resource));
         dispatch(setPlayingId(Number(resource?.howl?.play())));
       }
-      if (!!currentSound.howl) {
+      if (!!currentSound?.howl) {
         currentSound.howl.play();
       }
     }

--- a/front/src/component/Footer.tsx
+++ b/front/src/component/Footer.tsx
@@ -46,7 +46,7 @@ export default function Footer() {
     const volume: number = useSelector((state: any) => state.volume.volume);
     const dispatch = useDispatch();
     useInterval(() => {
-        if (currentSound.howl === undefined) return;
+        if (!currentSound?.howl) return;
         dispatch(setCurrentSeek(currentSound?.howl.seek()));
     });
     useEffect(() => {
@@ -104,7 +104,7 @@ export default function Footer() {
             dispatch(setPlayingId(Number(nextSound?.howl?.play())));
         }
     }
-    if (!!currentSound.howl) {
+    if (!!currentSound?.howl) {
         return (
             <div>
                 <Card style={{ width: "100%", position: "fixed", height: "100px", bottom: "0", backgroundColor: '#161B22', }}>

--- a/front/src/component/MusicsTable.tsx
+++ b/front/src/component/MusicsTable.tsx
@@ -119,7 +119,7 @@ export const Row = (props: {
                         size="small"
                         onClick={() => props.PlaySound(props.music)}
                     >
-                        {currentSound.filePath === 'static/musics/' + props.music.fileName && currentSound.howl?.playing() === true ?
+                        {currentSound?.filePath === 'static/musics/' + props.music.fileName && currentSound?.howl?.playing() === true ?
                             <PauseIcon style={{ color: 'white' }} /> : <PlayArrowIcon style={{ color: 'white' }} />}
                     </IconButton>
                 </TableCell>


### PR DESCRIPTION
currentSoundオブジェクトが空の際に、オブジェクトのkeyを参照しようとしてエラーが出ているだけだったので、オプショナルチェーンで解消。
