### PR TITLE
アルバム＿音源一覧で音源削除時の全曲表示バグ修正。Musics所得にcustomFookを使用できる箇所を修正。

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -72,25 +72,24 @@ def deleteMusics(ids):
             Music_Photo.query.filter(Music_Photo.musicId == id).delete()
 
     db.session.commit()
-    musics = Music.query.all()
-    return jsonify(MusicSchema(many=True).dump(musics))
+    return jsonify({"result": "OK", "id": id, "data": ""})
 
 
 # ---------- Groups ----------
-@app.route("/groups", methods=['GET'])
+@ app.route("/groups", methods=['GET'])
 def getGroups():
     groups = Group.query.all()
     return jsonify(GroupSchema(many=True).dump(groups))
 
 
 # ---------- Albums ----------
-@app.route("/albums", methods=['GET'])
+@ app.route("/albums", methods=['GET'])
 def getAlbums():
     albums = Album.query.all()
     return jsonify(AlbumSchema(many=True).dump(albums))
 
 
-@app.route("/albums-attached-music-count", methods=['GET'])
+@ app.route("/albums-attached-music-count", methods=['GET'])
 def getAlbumsAttachedMusicCount():
     ''' アルバムに紐づいた音源数を追加して返す '''
     albums = Album.query.all()
@@ -114,13 +113,13 @@ def getAlbumsAttachedMusicCount():
     return jsonify(AlbumAttachedMusicCountSchema(many=True).dump(albums))
 
 
-@app.route("/album/<id>", methods=['GET'])
+@ app.route("/album/<id>", methods=['GET'])
 def getAlbum(id):
     album = Album.query.filter(Album.id == id).one()
     return jsonify(AlbumSchema().dump(album))
 
 
-@app.route("/album", methods=['POST'])
+@ app.route("/album", methods=['POST'])
 def createAlbum():
     data = request.json
     newAlbum = Album(

--- a/front/src/AlbumPage.tsx
+++ b/front/src/AlbumPage.tsx
@@ -16,16 +16,16 @@ import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 // types
 import { Album } from './types/albums';
 import { AlbumAddMusicCount } from './types/albumsAddMusicCount';
-import type { Music } from './types/musics';
 import type { MusicResource } from './types/musicResource';
 // Redux
 import { useSelector, useDispatch } from 'react-redux';
 import { store } from './redux/store';
 import { setPlayingId } from './redux/playingIdSlice';
 import { setVolume } from './redux/volumeSlice';
-import { setMusics } from './redux/musicsSlice';
 import { setSounds } from './redux/soundsSlice';
 import { setCurrentSound } from './redux/currentSoundSlice';
+// hooks
+import useFetchMusics from './hooks/useFetchMusics';
 
 export default function AlbumPage() {
     const [albums, setAlbums] = useState<AlbumAddMusicCount[]>([]);
@@ -171,12 +171,12 @@ export const AlbumMedia = (props: { album: AlbumAddMusicCount, setSelectAlbum: R
 export const Album_MusicPage = (props: { album: AlbumAddMusicCount, setSelectAlbum: React.Dispatch<React.SetStateAction<AlbumAddMusicCount | undefined>> }) => {
     const { album, setSelectAlbum } = props;
     const [checkedNumbers, setCheckedNumbers] = useState<number[]>([]);
-    const musics: Music[] = useSelector((state: any) => state.musics.musics);
     const sounds: MusicResource[] = useSelector((state: any) => state.sounder.sounds);
     const playingId: number = useSelector((state: any) => state.playingId.playingId);
     const dispatch = useDispatch();
+    const { getMusics, musics } = useFetchMusics();
     useEffect(() => {
-        musicsGet();
+        getMusics("/musics/" + album.albumName);
         settingGet();
     }, []);
     useEffect(() => {
@@ -241,19 +241,12 @@ export const Album_MusicPage = (props: { album: AlbumAddMusicCount, setSelectAlb
             dispatch(setPlayingId(Number(nextSound?.howl?.play())));
         }
     }
-    function musicsGet() {
-        axios.get("/musics/" + album.albumName)
-            .then((response) => {
-                console.log(response.data);
-                dispatch(setMusics(response.data));
-            });
-    }
     function musicsDelete(ids: number[]) {
         console.log(ids);
         axios.delete("/musics/" + ids)
             .then((response) => {
                 console.log(response.data);
-                dispatch(setMusics(response.data));
+                getMusics("/musics/" + album.albumName);
             })
         setCheckedNumbers([]);
     }

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -8,7 +8,6 @@ import { useSelector, useDispatch } from 'react-redux';
 import { store } from './redux/store';
 import { setPlayingId } from './redux/playingIdSlice';
 import { setVolume } from './redux/volumeSlice';
-import { setMusics } from './redux/musicsSlice';
 import { setSounds } from './redux/soundsSlice';
 import { setCurrentSound } from './redux/currentSoundSlice';
 // components
@@ -100,7 +99,7 @@ function App() {
     axios.delete("/musics/" + ids)
       .then((response) => {
         console.log(response.data);
-        dispatch(setMusics(response.data));
+        getMusics("/musics");
       })
     setCheckedNumbers([]);
   }


### PR DESCRIPTION
関連Issue：アルバム＿音源一覧ページで音源削除・編集すると全曲表示されてしまう。 #105

- Music削除APIでMusicsをレスポンスとして返してしまっていたので、何も返さないように修正
- アルバム＿音源一覧で音源削除後に全曲表示されてしまうバグを修正。
- axios.getでMusicsの取得APIを呼んでいる箇所をCustomFookで呼ぶようにした。