### PR TITLE
音源情報を更新後に音源が一覧に全表示されるバグを修正

### DIFF
--- a/front/src/AlbumPage.tsx
+++ b/front/src/AlbumPage.tsx
@@ -274,6 +274,7 @@ export const Album_MusicPage = (props: { album: AlbumAddMusicCount, setSelectAlb
                 musics={musics}
                 checkedNumbers={checkedNumbers}
                 setCheckedNumbers={setCheckedNumbers}
+                musicsGetUrl={"/musics/" + album.albumName}
                 isDeleteButton={isDeleteButton}
                 musicsDelete={musicsDelete} />
             <Footer></Footer>

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -31,7 +31,6 @@ function App() {
     settingGet();
   }, [])
   useEffect(() => {
-    console.log('create');
     createHowler();
   }, [musics]);
   useEffect(() => {
@@ -124,6 +123,7 @@ function App() {
         musics={musics}
         checkedNumbers={checkedNumbers}
         setCheckedNumbers={setCheckedNumbers}
+        musicsGetUrl={"/musics"}
         isDeleteButton={isDeleteButton}
         musicsDelete={musicsDelete}></MusicTable>
 


### PR DESCRIPTION
- MusicTableコンポーネントにgetAPI用のURLを渡せるようにして、get処理をべた書きしなくて済むようにした。
- AlbumPageのアルバム＿音源一覧ページで音源情報を編集するとテーブルに音源が全曲表示されてしまうバグを修正。