### PR TITLE
削除ロジックをMusicTebleコンポーネント内に内包して共通化。

### DIFF
--- a/front/src/AlbumPage.tsx
+++ b/front/src/AlbumPage.tsx
@@ -170,7 +170,6 @@ export const AlbumMedia = (props: { album: AlbumAddMusicCount, setSelectAlbum: R
 
 export const Album_MusicPage = (props: { album: AlbumAddMusicCount, setSelectAlbum: React.Dispatch<React.SetStateAction<AlbumAddMusicCount | undefined>> }) => {
     const { album, setSelectAlbum } = props;
-    const [checkedNumbers, setCheckedNumbers] = useState<number[]>([]);
     const sounds: MusicResource[] = useSelector((state: any) => state.sounder.sounds);
     const playingId: number = useSelector((state: any) => state.playingId.playingId);
     const dispatch = useDispatch();
@@ -182,13 +181,6 @@ export const Album_MusicPage = (props: { album: AlbumAddMusicCount, setSelectAlb
     useEffect(() => {
         createHowler();
     }, [musics]);
-    useEffect(() => {
-        console.log('選択中のid:' + checkedNumbers.toString());
-    }, [checkedNumbers]);
-    const isDeleteButton = () => {
-        if (checkedNumbers.length !== 0) return true;
-        else return false;
-    }
     function createHowler() {
         let newSounds: MusicResource[] = [];
         musics.forEach(music => {
@@ -241,15 +233,6 @@ export const Album_MusicPage = (props: { album: AlbumAddMusicCount, setSelectAlb
             dispatch(setPlayingId(Number(nextSound?.howl?.play())));
         }
     }
-    function musicsDelete(ids: number[]) {
-        console.log(ids);
-        axios.delete("/musics/" + ids)
-            .then((response) => {
-                console.log(response.data);
-                getMusics("/musics/" + album.albumName);
-            })
-        setCheckedNumbers([]);
-    }
     function settingGet() {
         axios.get("/settings")
             .then((response) => {
@@ -272,11 +255,8 @@ export const Album_MusicPage = (props: { album: AlbumAddMusicCount, setSelectAlb
             </Grid>
             <MusicTable
                 musics={musics}
-                checkedNumbers={checkedNumbers}
-                setCheckedNumbers={setCheckedNumbers}
                 musicsGetUrl={"/musics/" + album.albumName}
-                isDeleteButton={isDeleteButton}
-                musicsDelete={musicsDelete} />
+            />
             <Footer></Footer>
         </div>
     )

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -1,5 +1,4 @@
 import { useEffect } from 'react';
-import { useState } from 'react';
 import './App.css';
 import { Howl } from 'howler';
 import axios from "axios"
@@ -21,7 +20,6 @@ import type { MusicResource } from './types/musicResource';
 
 function App() {
   // ステート
-  const [checkedNumbers, setCheckedNumbers] = useState<number[]>([]);
   const sounds: MusicResource[] = useSelector((state: any) => state.sounder.sounds);
   const playingId: number = useSelector((state: any) => state.playingId.playingId);
   const dispatch = useDispatch();
@@ -33,13 +31,6 @@ function App() {
   useEffect(() => {
     createHowler();
   }, [musics]);
-  useEffect(() => {
-    console.log('選択中のid:' + checkedNumbers.toString());
-  }, [checkedNumbers]);
-  const isDeleteButton = () => {
-    if (checkedNumbers.length !== 0) return true;
-    else return false;
-  }
   function createHowler() {
     let newSounds: MusicResource[] = [];
     musics.forEach(music => {
@@ -93,15 +84,6 @@ function App() {
       dispatch(setPlayingId(Number(nextSound?.howl?.play())));
     }
   }
-  function musicsDelete(ids: number[]) {
-    console.log(ids);
-    axios.delete("/musics/" + ids)
-      .then((response) => {
-        console.log(response.data);
-        getMusics("/musics");
-      })
-    setCheckedNumbers([]);
-  }
   function settingGet() {
     axios.get("/settings")
       .then((response) => {
@@ -121,11 +103,8 @@ function App() {
       {/* テーブル */}
       <MusicTable
         musics={musics}
-        checkedNumbers={checkedNumbers}
-        setCheckedNumbers={setCheckedNumbers}
         musicsGetUrl={"/musics"}
-        isDeleteButton={isDeleteButton}
-        musicsDelete={musicsDelete}></MusicTable>
+      />
 
       <div style={{ height: '150px' }}></div>
 

--- a/front/src/component/MusicsTable.tsx
+++ b/front/src/component/MusicsTable.tsx
@@ -4,7 +4,6 @@ import axios from 'axios';
 import { useForm, SubmitHandler, } from 'react-hook-form';
 // redux
 import { useSelector, useDispatch } from 'react-redux';
-import { setMusics } from '../redux/musicsSlice';
 import { setCurrentSound } from '../redux/currentSoundSlice';
 import { setPlayingId } from '../redux/playingIdSlice';
 // MUIComponents
@@ -32,18 +31,31 @@ import useFetchMusics from '../hooks/useFetchMusics';
 
 type MusicTableProp = {
     musics: Music[];
-    checkedNumbers: number[];
     musicsGetUrl: string;
-    setCheckedNumbers: React.Dispatch<React.SetStateAction<number[]>>;
-    isDeleteButton: () => boolean;
-    musicsDelete(ids: number[]): void
 }
 
 export default function MusicTable(props: MusicTableProp) {
-    const { musics, checkedNumbers } = props;
-    const { setCheckedNumbers } = props;
+    const { musics } = props;
     const { musicsGetUrl } = props;
-    const { isDeleteButton, musicsDelete } = props;
+    const [checkedNumbers, setCheckedNumbers] = useState<number[]>([]);
+    const { getMusics } = useFetchMusics();
+
+    const isDeleteButton = () => {
+        if (checkedNumbers.length !== 0) return true;
+        else return false;
+    }
+    function musicsDelete(ids: number[]) {
+        console.log(ids);
+        axios.delete("/musics/" + ids)
+            .then((response) => {
+                console.log(response.data);
+                getMusics(musicsGetUrl);
+            })
+        setCheckedNumbers([]);
+    }
+    useEffect(() => {
+        console.log('選択中のid:' + checkedNumbers.toString());
+    }, [checkedNumbers]);
     return (
         <Grid container>
             <Grid item xs>


### PR DESCRIPTION
カスタムフックuseFetchMusics作成によってMusics取得APIを共通化できたので、一旦リファクタリング。コード量削減。

- 削除ロジックをMusicTableコンポーネント内に内包し共通化。
- 削除チェックボックスの選択ロジックも共通化