### PR TITLE
PageTitleコンポーネント作成。photo-pageにHeaderとページタイトルのみ追加

### DIFF
--- a/front/src/PhotoPage.tsx
+++ b/front/src/PhotoPage.tsx
@@ -1,9 +1,13 @@
 import "./styles/main.scss";
+// components
+import Header from "./component/Header";
+import PageTitle from "./component/PageTitle";
 
 export default function PhotoPage() {
     return (
-        <div>
-            <p className="-white">This is PhotoPage</p>
-        </div>
+        <>
+            <Header />
+            <PageTitle title="Photos" />
+        </>
     )
 }

--- a/front/src/component/PageTitle.tsx
+++ b/front/src/component/PageTitle.tsx
@@ -1,0 +1,15 @@
+import "../styles/main.scss";
+// components
+import { Grid } from "@mui/material";
+
+export default function PageTitle(props: { title: string }) {
+    return (
+        <>
+            <Grid container>
+                <Grid item xs={1}></Grid>
+                <Grid item xs><h1 className="-white">{props.title}</h1></Grid>
+                <Grid item xs={1}></Grid>
+            </Grid>
+        </>
+    )
+}


### PR DESCRIPTION
- ページタイトルをコンポーネント化できそうだったのでコンポーネント化
- photoページに一旦Headerとページタイトルを追加する所まで